### PR TITLE
fixed: scan issue in voice state

### DIFF
--- a/packages/redis-adapter/src/adapter.ts
+++ b/packages/redis-adapter/src/adapter.ts
@@ -38,9 +38,9 @@ export class RedisAdapter implements Adapter {
 		});
 	}
 
-	async scan(query: string, returnKeys?: false): Promise<any[]>;
-	async scan(query: string, returnKeys: true): Promise<string[]>;
-	async scan(query: string, returnKeys = false) {
+	scan(query: string, returnKeys?: false): Promise<any[]>;
+	scan(query: string, returnKeys: true): Promise<string[]>;
+	scan(query: string, returnKeys = false) {
 		const match = this.buildKey(query);
 		return new Promise<string[] | any[]>((resolve, reject) => {
 			const keys: string[] = [];


### PR DESCRIPTION
```
[RAM Usage 66.64 MB] [1/9/2024 8:44:12 pm] FATAL seyfert > Unhandled Rejection at: Promise {
  <rejected> ReplyError: ERR syntax error
      at parseError (E:\coding\pvt\bot\node_modules\.pnpm\redis-parser@3.0.0\node_modules\redis-parser\lib\parser.js:179:12)
      at parseType (E:\coding\pvt\bot\node_modules\.pnpm\redis-parser@3.0.0\node_modules\redis-parser\lib\parser.js:302:14) {
    command: { name: 'scan', args: [Array] }
  }
} reason: ReplyError: ERR syntax error
    at parseError (E:\coding\pvt\bot\node_modules\.pnpm\redis-parser@3.0.0\node_modules\redis-parser\lib\parser.js:179:12)
    at parseType (E:\coding\pvt\bot\node_modules\.pnpm\redis-parser@3.0.0\node_modules\redis-parser\lib\parser.js:302:14) {
  command: {
    name: 'scan',
    args: [
      '0',
      'MATCH',
      'seyfert:voice_state.959703767333359630.*',
      'TYPE',
      'hash'
    ]
  }
}
```