### PR TITLE
feat: add scoped cooldown context plugin

### DIFF
--- a/packages/cooldown/src/index.ts
+++ b/packages/cooldown/src/index.ts
@@ -1,7 +1,45 @@
-import type { CooldownProps } from './manager';
+import type { AnyContext } from 'seyfert';
+import type { BaseClient } from 'seyfert/lib/client/base';
+import { type CooldownContextScope, CooldownManager, type CooldownProps, runWithCooldownContext } from './manager';
 
 export * from './manager';
 export * from './resource';
+
+export interface CooldownClient extends BaseClient {
+	cooldown?: CooldownManager;
+}
+
+export interface CooldownPlugin {
+	name: '@slipher/cooldown';
+	options(): {
+		context: () => { cooldown: CooldownManager };
+		contextScopes: readonly CooldownContextScope[];
+	};
+	setup(client: CooldownClient): void;
+}
+
+export function cooldown(): CooldownPlugin {
+	let manager: CooldownManager | undefined;
+
+	const contextScope: CooldownContextScope = (context, run) => runWithCooldownContext(context as AnyContext, run);
+	const getManager = () => {
+		if (!manager) throw new Error('@slipher/cooldown plugin setup has not run yet.');
+
+		return manager;
+	};
+
+	return {
+		name: '@slipher/cooldown',
+		options: () => ({
+			context: () => ({ cooldown: getManager() }),
+			contextScopes: [contextScope],
+		}),
+		setup: client => {
+			manager = new CooldownManager(client);
+			client.cooldown = manager;
+		},
+	};
+}
 
 export function Cooldown(props: CooldownProps) {
 	return <T extends { new (...args: any[]): {} }>(target: T) =>

--- a/packages/cooldown/src/manager.ts
+++ b/packages/cooldown/src/manager.ts
@@ -1,8 +1,29 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { AnyContext } from 'seyfert';
 import { CacheFrom, type ReturnCache } from 'seyfert/lib/cache';
 import type { BaseClient } from 'seyfert/lib/client/base';
 import { fakePromise, type PickPartial } from 'seyfert/lib/common';
 import { type CooldownData, CooldownResource, type CooldownType } from './resource';
+
+const cooldownContexts = new AsyncLocalStorage<AnyContext>();
+
+export type CooldownContextScope = <T>(context: unknown, run: () => T | Promise<T>) => T | Promise<T>;
+
+export interface CooldownContextOptions {
+	use?: keyof UsesProps;
+	guildId?: string;
+}
+
+export function runWithCooldownContext<T>(context: AnyContext, run: () => T | Promise<T>) {
+	return cooldownContexts.run(context, run);
+}
+
+export function useCooldownContext() {
+	const context = cooldownContexts.getStore();
+	if (!context) throw new Error('Cannot access cooldown context outside of a Seyfert cooldown scope.');
+
+	return context;
+}
 
 export class CooldownManager {
 	resource: CooldownResource;
@@ -71,7 +92,16 @@ export class CooldownManager {
 		});
 	}
 
-	context(context: AnyContext, use?: keyof UsesProps, guildId?: string) {
+	context(context: AnyContext, use?: keyof UsesProps, guildId?: string): ReturnCache<number | true>;
+	context(options?: CooldownContextOptions): ReturnCache<number | true>;
+	context(contextOrOptions?: AnyContext | CooldownContextOptions, use?: keyof UsesProps, guildId?: string) {
+		if (isCooldownContext(contextOrOptions)) return this.contextFrom(contextOrOptions, use, guildId);
+
+		const options = contextOrOptions ?? {};
+		return this.contextFrom(useCooldownContext(), options.use, options.guildId);
+	}
+
+	private contextFrom(context: AnyContext, use?: keyof UsesProps, guildId?: string) {
 		if (!('command' in context)) return true;
 		if (!('fullCommandName' in context)) return true;
 		const name = context.fullCommandName;
@@ -184,6 +214,14 @@ export class CooldownManager {
 	}
 }
 
+function isCooldownContext(context: unknown): context is AnyContext {
+	return (
+		typeof context === 'object' &&
+		context !== null &&
+		('author' in context || 'command' in context || 'fullCommandName' in context)
+	);
+}
+
 export interface CooldownProps {
 	/** target type */
 	type: `${CooldownType}`;
@@ -220,6 +258,21 @@ export interface UsesProps {
 }
 
 declare module 'seyfert' {
+	interface ExtendContext {
+		cooldown: CooldownManager;
+	}
+	interface UsingClient {
+		cooldown?: CooldownManager;
+	}
+	interface Client<Ready extends boolean = boolean> {
+		cooldown: CooldownManager;
+	}
+	interface HttpClient {
+		cooldown: CooldownManager;
+	}
+	interface WorkerClient<Ready extends boolean = boolean> {
+		cooldown: CooldownManager;
+	}
 	interface Command {
 		cooldown?: CooldownProps;
 	}

--- a/packages/cooldown/test/manager.test.mts
+++ b/packages/cooldown/test/manager.test.mts
@@ -1,8 +1,19 @@
-import { Cache, Client, Command, Logger, MemoryAdapter, SubCommand } from 'seyfert';
+import { Cache, Client, Command, Logger, MemoryAdapter, SubCommand, type AnyContext } from 'seyfert';
 import { HandleCommand } from 'seyfert/lib/commands/handle';
 import { CommandHandler } from 'seyfert/lib/commands/handler.js';
 import { assert, beforeEach, describe, test } from 'vitest';
-import { CooldownManager, type CooldownProps, CooldownType } from '../lib';
+import { CooldownManager, type CooldownProps, CooldownType, cooldown, runWithCooldownContext, useCooldownContext } from '../lib';
+
+function commandContext(overrides: Record<string, unknown> = {}) {
+	return {
+		command: {},
+		fullCommandName: 'testCommand',
+		author: { id: 'user1' },
+		guildId: 'guild1',
+		channelId: 'channel1',
+		...overrides,
+	} as unknown as AnyContext;
+}
 
 describe('CooldownManager', async () => {
 	let client: Client;
@@ -137,5 +148,51 @@ describe('CooldownManager', async () => {
 		const updatedResource = cooldownManager.resource.get(`${name}:user:${target}`);
 
 		assert.ok(updatedResource !== undefined);
+	});
+
+	test('context still accepts an explicit command context', async () => {
+		const result = await cooldownManager.context(commandContext());
+
+		assert.equal(result, true);
+		assert.equal(cooldownManager.resource.get('testCommand:user:user1')?.remaining, 2);
+	});
+
+	test('context throws a clear error when called without an active cooldown scope', () => {
+		assert.throws(() => cooldownManager.context(), /outside of a Seyfert cooldown scope/);
+	});
+
+	test('context uses the current scoped command context when omitted', async () => {
+		const result = await runWithCooldownContext(commandContext(), async () => cooldownManager.context());
+
+		assert.equal(result, true);
+		assert.equal(cooldownManager.resource.get('testCommand:user:user1')?.remaining, 2);
+	});
+
+	test('context accepts scoped options without manually passing the context', async () => {
+		const result = await runWithCooldownContext(commandContext({ fullCommandName: 'commandWithfakeGuildId' }), async () =>
+			cooldownManager.context({ guildId: '124' }),
+		);
+
+		assert.equal(result, true);
+		assert.equal(cooldownManager.resource.get('commandWithfakeGuildId:user:user1')?.remaining, 2);
+	});
+
+	test('cooldown plugin attaches a manager and registers a current context scope', async () => {
+		const plugin = cooldown();
+		const pluginOptions = plugin.options();
+		const clientWithCooldown = client as Client & { cooldown?: CooldownManager };
+
+		await plugin.setup(clientWithCooldown);
+
+		assert.equal(plugin.name, '@slipher/cooldown');
+		assert.ok(clientWithCooldown.cooldown instanceof CooldownManager);
+		assert.equal(pluginOptions?.context?.({}).cooldown, clientWithCooldown.cooldown);
+
+		const scope = pluginOptions?.contextScopes?.[0];
+		assert.equal(typeof scope, 'function');
+
+		await scope?.(commandContext(), async () => {
+			assert.equal(useCooldownContext().fullCommandName, 'testCommand');
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- add a `cooldown()` Seyfert plugin that attaches `ctx.cooldown` and `client.cooldown`
- add a cooldown context scope backed by AsyncLocalStorage so commands can call `ctx.cooldown.context()` without passing `ctx` again
- keep the explicit `ctx.cooldown.context(ctx, use, guildId)` path working, plus scoped options like `ctx.cooldown.context({ guildId })`

## Notes
- Runtime scope registration is designed for the Seyfert plugin/contextScopes PR: https://github.com/tiramisulabs/seyfert/pull/391
- The package keeps structural plugin types so it still builds against the currently published Seyfert dependency.

## Validation
- `pnpm --filter @slipher/cooldown checkb`
- `pnpm --filter @slipher/cooldown build`
- `pnpm --filter @slipher/cooldown test`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`