### PR TITLE
fix: harden proxy and webhook parsing

### DIFF
--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,11 +1,53 @@
-# Rest proxy using [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js)
+# @slipher/proxy
+
+REST proxy for Seyfert using [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js).
+
+## Install
+
+```sh
+pnpm add @slipher/proxy
+```
+
+## Usage
 
 ```ts
-const { app } = await createProxy({
+import { createProxy } from '@slipher/proxy';
+
+const { app, result } = await createProxy({
 	port: 4444,
-	token: "MzUxNDMzMTk0MDAxNjYxOTUy........",
-	baseUrl?...
-	app?...
-	rest?...
+	token: process.env.DISCORD_TOKEN!,
+	baseUrl: '/api',
 });
+
+if (!result) {
+	throw new Error('Proxy failed to listen.');
+}
+```
+
+Requests must include the same bot token used by the proxy:
+
+```http
+Authorization: Bot <token>
+```
+
+The proxy forwards the method, route, query string, JSON body, files, and `x-audit-log-reason` header to Seyfert's `ApiHandler`. Pass `rest` when you already have an `ApiHandler` instance, or `app` when you want to mount the proxy onto an existing uWebSockets app.
+
+## Request Bodies
+
+`GET` and `DELETE` requests are forwarded without reading a body.
+
+For other methods:
+
+- `multipart/form-data` bodies are parsed with uWebSockets `getParts()`.
+- Other content types are parsed as JSON objects.
+- Missing `content-type` skips the multipart path and is handled as JSON.
+- Malformed JSON or non-object JSON returns `400`.
+
+File fields use the field name as `filename`, then the uploaded filename, then a generated `file-<index>` fallback.
+
+## Development
+
+```sh
+pnpm --filter @slipher/proxy test
+pnpm --filter @slipher/proxy build
 ```

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,6 +18,7 @@
 		"lint": "biome lint --write ./src",
 		"format": "biome format --write ./src",
 		"checkb": "biome check --write --no-errors-on-unmatched ./src",
+		"test": "vitest run ./test/",
 		"prepublish": "pnpm build"
 	},
 	"dependencies": {

--- a/packages/proxy/src/adapter.ts
+++ b/packages/proxy/src/adapter.ts
@@ -7,6 +7,15 @@ import {
 	type us_listen_socket,
 } from 'uWebSockets.js';
 import { ApiHandler, type HttpMethods, type RawFile } from 'seyfert';
+import { parseJsonObject, parseMultipartBody } from './parsing';
+
+function writeBadRequest(res: HttpResponse, message: string) {
+	if (!res.aborted)
+		res.cork(() => {
+			res.writeStatus('400').writeHeader('content-type', 'application/json').end(JSON.stringify({ message }));
+		});
+}
+
 export function createProxy(options: {
 	token: string;
 	port: number;
@@ -38,7 +47,7 @@ export function createProxy(options: {
 			return;
 		}
 		let body: undefined | Record<string, unknown>;
-		const files: RawFile[] = [];
+		let files: RawFile[] = [];
 		const method = <HttpMethods>req.getMethod().toUpperCase();
 		const query = new URLSearchParams(req.getQuery());
 		const path = <`/${string}`>req.getUrl().slice(sliceLength);
@@ -46,21 +55,18 @@ export function createProxy(options: {
 		if (method !== 'GET' && method !== 'DELETE') {
 			const contentType = req.getHeader('content-type');
 			if (contentType.includes('multipart/form-data')) {
-				const form = await readBody(res, req);
+				const form = await readBody(res, req, contentType);
 				if (form) {
-					for (let i = 0; i < form.length; i++) {
-						const field = form[i];
-						if (field.name === 'payload_json') {
-							body = JSON.parse(Buffer.from(field.data).toString());
-						} else {
-							files.push({
-								filename: field.filename!,
-								data: field.data,
-							});
-						}
-					}
+					const parsed = parseMultipartBody(form);
+					if (!parsed.ok) return writeBadRequest(res, parsed.message);
+					body = parsed.body;
+					files = parsed.files;
 				}
-			} else body = await readJson(res);
+			} else {
+				const parsed = parseJsonObject(await readBuffer(res));
+				if (!parsed.ok) return writeBadRequest(res, parsed.message);
+				body = parsed.value;
+			}
 		}
 		try {
 			const result = await rest.request(method, path, {
@@ -119,8 +125,7 @@ export async function readJson<T extends Record<string, any>>(res: HttpResponse)
 	return JSON.parse(buffer.toString());
 }
 
-export async function readBody(res: HttpResponse, req: HttpRequest) {
-	const contentType = req.getHeader('content-type');
+export async function readBody(res: HttpResponse, req: HttpRequest, contentType = req.getHeader('content-type')) {
 	const buffer = await readBuffer(res);
 	return getParts(buffer, contentType);
 }

--- a/packages/proxy/src/adapter.ts
+++ b/packages/proxy/src/adapter.ts
@@ -7,7 +7,7 @@ import {
 	type us_listen_socket,
 } from 'uWebSockets.js';
 import { ApiHandler, type HttpMethods, type RawFile } from 'seyfert';
-import { parseJsonObject, parseMultipartBody } from './parsing';
+import { isMultipartContentType, parseJsonObject, parseMultipartBody } from './parsing';
 
 function writeBadRequest(res: HttpResponse, message: string) {
 	if (!res.aborted)
@@ -54,7 +54,7 @@ export function createProxy(options: {
 		const reason = req.getHeader('x-audit-log-reason');
 		if (method !== 'GET' && method !== 'DELETE') {
 			const contentType = req.getHeader('content-type');
-			if (contentType.includes('multipart/form-data')) {
+			if (isMultipartContentType(contentType)) {
 				const form = await readBody(res, req, contentType);
 				if (form) {
 					const parsed = parseMultipartBody(form);

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,1 +1,2 @@
 export { createProxy } from './adapter';
+export { parseJsonObject, parseMultipartBody } from './parsing';

--- a/packages/proxy/src/parsing.ts
+++ b/packages/proxy/src/parsing.ts
@@ -21,6 +21,10 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+export function isMultipartContentType(contentType: string | undefined): contentType is string {
+	return contentType?.includes('multipart/form-data') === true;
+}
+
 export function parseJsonObject(input: string | Buffer | ArrayBuffer): JsonObjectResult {
 	const raw =
 		typeof input === 'string'

--- a/packages/proxy/src/parsing.ts
+++ b/packages/proxy/src/parsing.ts
@@ -1,0 +1,63 @@
+import type { RawFile } from 'seyfert';
+
+export interface MultipartFieldLike {
+	name: string;
+	data: ArrayBuffer;
+	filename?: string;
+}
+
+export interface BadRequestResult {
+	ok: false;
+	status: 400;
+	message: string;
+}
+
+export type JsonObjectResult = { ok: true; value: Record<string, unknown> } | BadRequestResult;
+export type MultipartBodyResult =
+	| { ok: true; body: Record<string, unknown> | undefined; files: RawFile[] }
+	| BadRequestResult;
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseJsonObject(input: string | Buffer | ArrayBuffer): JsonObjectResult {
+	const raw =
+		typeof input === 'string'
+			? input
+			: Buffer.isBuffer(input)
+				? input.toString()
+				: Buffer.from(new Uint8Array(input)).toString();
+	let value: unknown;
+
+	try {
+		value = JSON.parse(raw);
+	} catch {
+		return { ok: false, status: 400, message: 'Malformed JSON body.' };
+	}
+
+	if (!isJsonObject(value)) return { ok: false, status: 400, message: 'Expected a JSON object body.' };
+	return { ok: true, value };
+}
+
+export function parseMultipartBody(fields: MultipartFieldLike[]): MultipartBodyResult {
+	let body: Record<string, unknown> | undefined;
+	const files: RawFile[] = [];
+
+	for (let i = 0; i < fields.length; i++) {
+		const field = fields[i];
+		if (field.name === 'payload_json') {
+			const parsed = parseJsonObject(field.data);
+			if (!parsed.ok) return parsed;
+			body = parsed.value;
+			continue;
+		}
+
+		files.push({
+			filename: field.filename || field.name || `file-${i}`,
+			data: field.data,
+		});
+	}
+
+	return { ok: true, body, files };
+}

--- a/packages/proxy/test/adapter.test.mts
+++ b/packages/proxy/test/adapter.test.mts
@@ -1,11 +1,17 @@
 import { assert, describe, test } from 'vitest';
-import { parseJsonObject, parseMultipartBody } from '../src/parsing';
+import { isMultipartContentType, parseJsonObject, parseMultipartBody } from '../src/parsing';
 
 function bytes(value: string) {
 	return new TextEncoder().encode(value).buffer;
 }
 
 describe('@slipher/proxy request parsing', () => {
+	test('isMultipartContentType rejects missing headers', () => {
+		assert.equal(isMultipartContentType(undefined), false);
+		assert.equal(isMultipartContentType('application/json'), false);
+		assert.equal(isMultipartContentType('multipart/form-data; boundary=body'), true);
+	});
+
 	test('parseJsonObject accepts only JSON objects', () => {
 		assert.deepEqual(parseJsonObject('{"content":"hello"}'), { ok: true, value: { content: 'hello' } });
 		assert.deepEqual(parseJsonObject('[]'), { ok: false, status: 400, message: 'Expected a JSON object body.' });

--- a/packages/proxy/test/adapter.test.mts
+++ b/packages/proxy/test/adapter.test.mts
@@ -1,0 +1,39 @@
+import { assert, describe, test } from 'vitest';
+import { parseJsonObject, parseMultipartBody } from '../src/parsing';
+
+function bytes(value: string) {
+	return new TextEncoder().encode(value).buffer;
+}
+
+describe('@slipher/proxy request parsing', () => {
+	test('parseJsonObject accepts only JSON objects', () => {
+		assert.deepEqual(parseJsonObject('{"content":"hello"}'), { ok: true, value: { content: 'hello' } });
+		assert.deepEqual(parseJsonObject('[]'), { ok: false, status: 400, message: 'Expected a JSON object body.' });
+		assert.deepEqual(parseJsonObject('{'), { ok: false, status: 400, message: 'Malformed JSON body.' });
+	});
+
+	test('parseMultipartBody parses payload_json and falls back unnamed file names', () => {
+		const parsed = parseMultipartBody([
+			{ name: 'payload_json', data: bytes('{"content":"hello"}') },
+			{ name: 'upload', data: bytes('a') },
+			{ name: '', filename: 'named.txt', data: bytes('b') },
+			{ name: '', data: bytes('c') },
+		]);
+
+		assert.equal(parsed.ok, true);
+		if (!parsed.ok) return;
+		assert.deepEqual(parsed.body, { content: 'hello' });
+		assert.deepEqual(
+			parsed.files.map(file => file.filename),
+			['upload', 'named.txt', 'file-3'],
+		);
+	});
+
+	test('parseMultipartBody rejects malformed payload_json', () => {
+		assert.deepEqual(parseMultipartBody([{ name: 'payload_json', data: bytes('{') }]), {
+			ok: false,
+			status: 400,
+			message: 'Malformed JSON body.',
+		});
+	});
+});

--- a/packages/webhooks/README.md
+++ b/packages/webhooks/README.md
@@ -1,26 +1,59 @@
-# Webhook Events
+# @slipher/webhooks
 
-Completely agnostic and minimalistic way with 1 dependencies to listen to Discord webhook events.
+Minimal HTTP listener for Discord webhook events.
+
+## Install
+
+```sh
+pnpm add @slipher/webhooks
+```
+
+## Usage
 
 ```ts
-import { init } from '@slipher/webhooks'
+import { init } from '@slipher/webhooks';
 
 const server = init({
 	port: 3000,
 	path: '/api/webhooks',
-	callback: (event) => console.log(event),
-	listen: () => console.log('Listen webhooks'),
+	publicKey: process.env.DISCORD_PUBLIC_KEY!,
+	callback: event => {
+		console.log(event);
+	},
+	listen: () => console.log('Listening for webhooks'),
 });
 ```
-### To complete the typing you must use the augmentation module provided by typescript
+
+The listener accepts `POST` requests at the configured `path`, verifies Discord's Ed25519 signature with `x-signature-timestamp`, `x-signature-ed25519`, and `publicKey`, then calls `callback` for event payloads.
+
+## Responses
+
+- Non-`POST` requests return `405`.
+- Requests to another path return `401`.
+- Invalid signatures return `401`.
+- Malformed JSON or non-object JSON returns `400`.
+- Bodies larger than 1 MB return `413`.
+- Valid Discord ping and event payloads return `204`.
+
+## Type Augmentation
+
+To complete the event typing, augment the webhook interfaces with your API types.
 
 **Seyfert**
+
 ```ts
-import type { APIUser, APIGuild, APIEntitlement } from "seyfert/lib/types";
+import type { APIEntitlement, APIGuild, APIUser } from 'seyfert/lib/types';
 
 declare module '@slipher/webhooks' {
 	export interface EntitlementCreateEventType extends APIEntitlement {}
 	export interface UserType extends APIUser {}
 	export interface GuildType extends APIGuild {}
 }
+```
+
+## Development
+
+```sh
+pnpm --filter @slipher/webhooks test
+pnpm --filter @slipher/webhooks build
 ```

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -18,6 +18,7 @@
 		"lint": "biome lint --write ./src",
 		"format": "biome format --write ./src",
 		"checkb": "biome check --write --no-errors-on-unmatched ./src",
+		"test": "vitest run ./test/",
 		"prepublish": "pnpm build"
 	},
 	"devDependencies": {

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -9,6 +9,7 @@ export interface BadWebhookPayloadResult {
 
 export type WebhookPayload = WebhookPingEventPayload | WebhookEventPayload;
 export type WebhookPayloadResult = { ok: true; body: WebhookPayload } | BadWebhookPayloadResult;
+export const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -32,12 +33,23 @@ export const init = (options: AppOptions) => {
 		if (req.url !== options.path) return res.writeHead(401).end();
 
 		let rawBody = '';
+		let bodySize = 0;
+		let bodyTooLarge = false;
 
 		req.on('data', chunk => {
+			if (bodyTooLarge) return;
+			bodySize += Buffer.byteLength(chunk);
+			if (bodySize > MAX_WEBHOOK_BODY_BYTES) {
+				bodyTooLarge = true;
+				rawBody = '';
+				res.writeHead(413).end();
+				return;
+			}
 			rawBody += chunk.toString(); // Append each chunk of data
 		});
 
 		req.on('end', () => {
+			if (bodyTooLarge) return;
 			let verify: boolean;
 			try {
 				verify = verifySignature({

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,6 +1,31 @@
 import { createServer } from 'node:http';
 import nacl from 'tweetnacl';
 
+export interface BadWebhookPayloadResult {
+	ok: false;
+	status: 400;
+	message: string;
+}
+
+export type WebhookPayload = WebhookPingEventPayload | WebhookEventPayload;
+export type WebhookPayloadResult = { ok: true; body: WebhookPayload } | BadWebhookPayloadResult;
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseWebhookPayload(rawBody: string): WebhookPayloadResult {
+	let body: unknown;
+	try {
+		body = JSON.parse(rawBody);
+	} catch {
+		return { ok: false, status: 400, message: 'Malformed JSON body.' };
+	}
+
+	if (!isJsonObject(body)) return { ok: false, status: 400, message: 'Expected a JSON object body.' };
+	return { ok: true, body: body as unknown as WebhookPayload };
+}
+
 export const init = (options: AppOptions) => {
 	const server = createServer((req, res) => {
 		if (req.method !== 'POST') return res.writeHead(405).end();
@@ -27,7 +52,9 @@ export const init = (options: AppOptions) => {
 			}
 
 			if (verify) {
-				const body = JSON.parse(rawBody);
+				const parsed = parseWebhookPayload(rawBody);
+				if (!parsed.ok) return res.writeHead(parsed.status).end(JSON.stringify({ message: parsed.message }));
+				const body = parsed.body;
 				if (body.type === WebhookRequestType.Event) options.callback(body);
 				return res.writeHead(204).end();
 			}

--- a/packages/webhooks/test/index.test.mts
+++ b/packages/webhooks/test/index.test.mts
@@ -1,5 +1,7 @@
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { assert, describe, test } from 'vitest';
-import { parseWebhookPayload, WebhookRequestType } from '../src';
+import { init, MAX_WEBHOOK_BODY_BYTES, parseWebhookPayload, WebhookRequestType } from '../src';
 
 describe('@slipher/webhooks payload parsing', () => {
 	test('parseWebhookPayload accepts JSON objects', () => {
@@ -16,5 +18,31 @@ describe('@slipher/webhooks payload parsing', () => {
 	test('parseWebhookPayload rejects malformed or non-object JSON', () => {
 		assert.deepEqual(parseWebhookPayload('{'), { ok: false, status: 400, message: 'Malformed JSON body.' });
 		assert.deepEqual(parseWebhookPayload('[]'), { ok: false, status: 400, message: 'Expected a JSON object body.' });
+	});
+
+	test('init rejects bodies larger than the webhook size limit', async () => {
+		let server!: Server;
+		await new Promise<void>(resolve => {
+			server = init({
+				path: '/webhook',
+				port: 0,
+				publicKey: '0'.repeat(64),
+				callback: () => undefined,
+				listen: resolve,
+			});
+		});
+
+		try {
+			const address = server.address();
+			assert.notEqual(address, null);
+			assert.notEqual(typeof address, 'string');
+			const response = await fetch(`http://127.0.0.1:${(address as AddressInfo).port}/webhook`, {
+				method: 'POST',
+				body: 'x'.repeat(MAX_WEBHOOK_BODY_BYTES + 1),
+			});
+			assert.equal(response.status, 413);
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
 	});
 });

--- a/packages/webhooks/test/index.test.mts
+++ b/packages/webhooks/test/index.test.mts
@@ -1,0 +1,20 @@
+import { assert, describe, test } from 'vitest';
+import { parseWebhookPayload, WebhookRequestType } from '../src';
+
+describe('@slipher/webhooks payload parsing', () => {
+	test('parseWebhookPayload accepts JSON objects', () => {
+		assert.deepEqual(parseWebhookPayload('{"type":0,"version":1,"application_id":"app"}'), {
+			ok: true,
+			body: {
+				type: WebhookRequestType.PING,
+				version: 1,
+				application_id: 'app',
+			},
+		});
+	});
+
+	test('parseWebhookPayload rejects malformed or non-object JSON', () => {
+		assert.deepEqual(parseWebhookPayload('{'), { ok: false, status: 400, message: 'Malformed JSON body.' });
+		assert.deepEqual(parseWebhookPayload('[]'), { ok: false, status: 400, message: 'Expected a JSON object body.' });
+	});
+});


### PR DESCRIPTION
## Summary

- reject malformed and non-object JSON bodies in `@slipher/proxy` with 400 responses
- add shared proxy parsing helpers for JSON and multipart payloads
- reject malformed Discord webhook payload JSON in `@slipher/webhooks`
- add regression tests for proxy and webhook parsing

## Validation

- `pnpm --filter @slipher/proxy build`
- `pnpm --filter @slipher/webhooks build`
- `pnpm --filter @slipher/proxy checkb`
- `pnpm --filter @slipher/webhooks checkb`
- `pnpm exec vitest run packages/proxy/test packages/webhooks/test`
