### PR TITLE
fix: mark turbo one-shot tasks non-persistent

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,24 +7,20 @@
 			"outputs": ["lib/**"]
 		},
 		"test": {
-			"cache": false,
-			"persistent": true
+			"cache": false
 		},
 		"dev": {
 			"cache": false,
 			"persistent": true
 		},
 		"lint": {
-			"cache": false,
-			"persistent": true
+			"cache": false
 		},
 		"format": {
-			"cache": false,
-			"persistent": true
+			"cache": false
 		},
 		"checkb": {
-			"cache": false,
-			"persistent": true
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
## What
- Removes `persistent: true` from Turbo one-shot tasks: `test`, `lint`, `format`, and `checkb`.
- Keeps `dev` persistent.

## Why
CI runs these tasks as finite commands. Marking them persistent makes Turbo reject or hang one-shot CI orchestration.

## Validation
- `pnpm run format`
- `pnpm run check`